### PR TITLE
fix tokenizer initialization bug with the latest version (4.34.0.dev0) of transformers

### DIFF
--- a/OpenBA/tokenization_openba.py
+++ b/OpenBA/tokenization_openba.py
@@ -127,6 +127,12 @@ class OpenBATokenizer(PreTrainedTokenizer):
 
         self.sp_model_kwargs = {} if sp_model_kwargs is None else sp_model_kwargs
 
+        self.vocab_file = vocab_file
+        self._extra_ids = extra_ids
+
+        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
+        self.sp_model.Load(vocab_file)
+
         super().__init__(
             eos_token=eos_token,
             unk_token=unk_token,
@@ -136,12 +142,6 @@ class OpenBATokenizer(PreTrainedTokenizer):
             sp_model_kwargs=self.sp_model_kwargs,
             **kwargs,
         )
-
-        self.vocab_file = vocab_file
-        self._extra_ids = extra_ids
-
-        self.sp_model = spm.SentencePieceProcessor(**self.sp_model_kwargs)
-        self.sp_model.Load(vocab_file)
 
     @staticmethod
     def _eventually_correct_t5_max_length(pretrained_model_name_or_path, max_model_length, init_max_model_length):


### PR DESCRIPTION
Move `super().__init__()` to the end of `__init__` to fix tokenizer loading bug.
Otherwise, the following error is encountered:

```
Loading the tokenizer from the `special_tokens_map.json` and the `added_tokens.json` will be removed in `transformers 5`,  it is kept for forward compatibility, but it is recommended to update your `tokenizer_config.json` by uploading it again. You will see the new `added_tokens_decoder` attribute that will store the relevant information.
Traceback (most recent call last):
  File "/data/zhutong/OpenBA-Enc/debug.py", line 3, in <module>
    tokenizer = AutoTokenizer.from_pretrained(
  File "/home/zhutong/miniconda3/envs/torch/lib/python3.10/site-packages/transformers/models/auto/tokenization_auto.py", line 731, in from_pretrained
    return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
  File "/home/zhutong/miniconda3/envs/torch/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 2039, in from_pretrained
    return cls._from_pretrained(
  File "/home/zhutong/miniconda3/envs/torch/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 2250, in _from_pretrained
    tokenizer = cls(*init_inputs, **init_kwargs)
  File "/home/zhutong/.cache/huggingface/modules/transformers_modules/OpenBA/OpenBA-LM/330fa80ff08f9646728dc14b568b60ea3d9d8144/tokenization_openba.py", line 52, in __init__
    super().__init__(
  File "/home/zhutong/miniconda3/envs/torch/lib/python3.10/site-packages/transformers/tokenization_utils.py", line 366, in __init__
    self._add_tokens(self.all_special_tokens_extended, special_tokens=True)
  File "/home/zhutong/miniconda3/envs/torch/lib/python3.10/site-packages/transformers/tokenization_utils.py", line 454, in _add_tokens
    current_vocab = self.get_vocab().copy()
  File "/home/zhutong/.cache/huggingface/modules/transformers_modules/OpenBA/OpenBA-LM/330fa80ff08f9646728dc14b568b60ea3d9d8144/tokenization_openba.py", line 95, in get_vocab
    vocab = {self.convert_ids_to_tokens(i): i for i in range(self.vocab_size)}
  File "/home/zhutong/.cache/huggingface/modules/transformers_modules/OpenBA/OpenBA-LM/330fa80ff08f9646728dc14b568b60ea3d9d8144/tokenization_openba.py", line 92, in vocab_size
    return self.sp_model.get_piece_size() + self._extra_ids
AttributeError: 'OpenBATokenizer' object has no attribute 'sp_model'
```